### PR TITLE
Remove `commentPullRequests` input

### DIFF
--- a/extensions/azure/README.md
+++ b/extensions/azure/README.md
@@ -57,7 +57,6 @@ Dependabot uses Docker containers, which may take time to install if not already
 |--|--|
 |skipPullRequests|**_Optional_**. Determines whether to skip creation and updating of pull requests. When set to `true` the logic to update the dependencies is executed but the actual Pull Requests are not created/updated. This is useful for debugging. Defaults to `false`.|
 |abandonUnwantedPullRequests|**_Optional_**. Determines whether to abandon unwanted pull requests. Defaults to `false`.|
-|commentPullRequests|**_Optional_**. Determines whether to comment on pull requests with an explanation of the reason for closing. Defaults to `false`.|
 |setAutoComplete|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically. Defaults to `false`.|
 |mergeStrategy|**_Optional_**. The merge strategy to use when auto complete is set. Learn more [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0&tabs=HTTP#gitpullrequestmergestrategy). Defaults to `squash`.|
 |autoCompleteIgnoreConfigIds|**_Optional_**. List of any policy configuration Id's which auto-complete should not wait for. Only applies to optional policies. Auto-complete always waits for required (blocking) policies.|

--- a/extensions/azure/src/dependabot/output-processor.ts
+++ b/extensions/azure/src/dependabot/output-processor.ts
@@ -276,7 +276,7 @@ export class DependabotOutputProcessor {
           project: project,
           repository: repository,
           pullRequestId: pullRequestToClose.id,
-          comment: this.taskInputs.commentPullRequests ? getPullRequestCloseReasonForOutputData(data) : undefined,
+          comment: getPullRequestCloseReasonForOutputData(data),
           deleteSourceBranch: true,
         });
       }

--- a/extensions/azure/src/task-v2.ts
+++ b/extensions/azure/src/task-v2.ts
@@ -210,12 +210,15 @@ export async function abandonPullRequestsWhereSourceRefIsDeleted(
           project: taskInputs.project,
           repository: taskInputs.repository,
           pullRequestId: pullRequest.id,
-          comment: taskInputs.commentPullRequests
-            ? "OK, I won't notify you again about this release, but will get in touch when a new version is available. " +
-              "If you'd rather skip all updates until the next major or minor version, add an " +
-              '[`ignore` condition](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) ' +
-              'with the desired `update-types` to your config file.'
-            : undefined,
+          // comment:
+          //   "OK, I won't notify you again about this release, but will get in touch when a new version is available. " +
+          //   "If you'd rather skip all updates until the next major or minor version, add an " +
+          //   '[`ignore` condition](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) ' +
+          //   'with the desired `update-types` to your config file.',
+          comment:
+            'It might be a good idea to add an ' +
+            '[`ignore` condition](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) ' +
+            'with the desired `update-types` to your config file.',
         });
       }
 

--- a/extensions/azure/src/utils/shared-variables.ts
+++ b/extensions/azure/src/utils/shared-variables.ts
@@ -65,8 +65,6 @@ export interface ISharedVariables {
 
   /** Determines whether to skip creating/updating pull requests */
   skipPullRequests: boolean;
-  /** Determines whether to comment on pull requests which an explanation of the reason for closing */
-  commentPullRequests: boolean;
   /** Determines whether to abandon unwanted pull requests */
   abandonUnwantedPullRequests: boolean;
 
@@ -180,7 +178,6 @@ export default function getSharedVariables(): ISharedVariables {
   // Prepare other variables
   const securityAdvisoriesFile: string | undefined = tl.getInput('securityAdvisoriesFile');
   const skipPullRequests: boolean = tl.getBoolInput('skipPullRequests', false);
-  const commentPullRequests: boolean = tl.getBoolInput('commentPullRequests', false);
   const abandonUnwantedPullRequests: boolean = tl.getBoolInput('abandonUnwantedPullRequests', true);
 
   const dependabotCliPackage: string | undefined = tl.getInput('dependabotCliPackage');
@@ -228,7 +225,6 @@ export default function getSharedVariables(): ISharedVariables {
     securityAdvisoriesFile,
 
     skipPullRequests,
-    commentPullRequests,
     abandonUnwantedPullRequests,
 
     dependabotCliPackage,

--- a/extensions/azure/tasks/dependabotV2/task.json
+++ b/extensions/azure/tasks/dependabotV2/task.json
@@ -66,16 +66,6 @@
       "helpMarkDown": "When set to `true` pull requests that are no longer needed are closed at the tail end of the execution. Defaults to `false`."
     },
     {
-      "name": "commentPullRequests",
-      "type": "boolean",
-      "groupName": "pull_requests",
-      "label": "Comment on abandoned pull requests with close reason.",
-      "defaultValue": false,
-      "required": false,
-      "helpMarkDown": "When set to `true` a comment will be added to abandoned pull requests explanating why it was closed. Defaults to `false`.",
-      "visibleRule": "abandonUnwantedPullRequests=true"
-    },
-    {
       "name": "setAutoComplete",
       "type": "boolean",
       "groupName": "pull_requests",

--- a/extensions/azure/tests/task-v2.test.ts
+++ b/extensions/azure/tests/task-v2.test.ts
@@ -58,6 +58,10 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
 
     expect(devOpsPrAuthorClient.abandonPullRequest).toHaveBeenCalledWith({
       pullRequestId: 1,
+      comment:
+        'It might be a good idea to add an ' +
+        '[`ignore` condition](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--) ' +
+        'with the desired `update-types` to your config file.',
     });
   });
 


### PR DESCRIPTION
When a PR is abandoned, some people do not know why because the input is `commentPullRequests: false` by default. For consistency with the GitHub hosted version, it only makes sense to remove this input and have comments added.