### PR TITLE
Normalize directory in branch name

### DIFF
--- a/extensions/azure/eslint.config.mjs
+++ b/extensions/azure/eslint.config.mjs
@@ -6,10 +6,4 @@ export default [
   {
     ignores: ['tasks/*/dist/**'],
   },
-  {
-    rules: {
-      // TODO: remove this after writing tests for src/dependabot/branch-name.ts
-      'no-useless-escape': 'off',
-    },
-  },
 ];

--- a/extensions/azure/tests/dependabot/branch-name.test.ts
+++ b/extensions/azure/tests/dependabot/branch-name.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { getBranchNameForUpdate, sanitizeRef } from '../../src/dependabot/branch-name';
+
+describe('getBranchNameForUpdate', () => {
+  it('generates correct branch name for a single dependency update', () => {
+    const result = getBranchNameForUpdate('npm', 'main', '/packages/ui', undefined, [
+      { 'dependency-name': 'lodash', 'dependency-version': '4.17.21' },
+    ]);
+    expect(result).toBe('dependabot/npm/main/packages/ui/lodash-4.17.21');
+  });
+
+  it('generates correct branch name for a removed dependency', () => {
+    const result = getBranchNameForUpdate('npm', 'main', '/', undefined, [
+      { 'dependency-name': 'react', 'removed': true },
+    ]);
+    expect(result).toBe('dependabot/npm/main/react-removed');
+  });
+
+  it('generates correct branch name for a grouped update (with group name)', () => {
+    const result = getBranchNameForUpdate('nuget', 'develop', '/', 'microsoft', [
+      { 'dependency-name': 'Microsoft.Extensions.Logging', 'dependency-version': '1.0.0' },
+      { 'dependency-name': 'Microsoft.Extensions.Http', 'dependency-version': '2.0.0' },
+    ]);
+    expect(result).toMatch(/^dependabot\/nuget\/develop\/microsoft-[a-f0-9]{10}$/);
+  });
+
+  it('generates correct branch name for multiple dependencies (no group name)', () => {
+    const result = getBranchNameForUpdate('pip', 'main', '/src', undefined, [
+      { 'dependency-name': 'numpy', 'dependency-version': '1.24.0' },
+      { 'dependency-name': 'pandas', 'dependency-version': '2.1.0' },
+    ]);
+    expect(result).toMatch(/^dependabot\/pip\/main\/src\/multi-[a-f0-9]{10}$/);
+  });
+
+  it('respects custom separator', () => {
+    const result = getBranchNameForUpdate(
+      'npm',
+      'main',
+      '/',
+      undefined,
+      [{ 'dependency-name': 'lodash', 'dependency-version': '4.17.21' }],
+      '__',
+    );
+    expect(result).toBe('dependabot__npm__main__lodash-4.17.21');
+  });
+
+  it('normalizes directory with leading/trailing slashes', () => {
+    const result = getBranchNameForUpdate(
+      'npm',
+      'main',
+      '/some/deep/path/',
+      '',
+      [{ 'dependency-name': 'express', 'dependency-version': '4.18.2' }],
+      '-',
+    );
+
+    expect(result).toBe(`dependabot-npm-main-some-deep-path-express-4.18.2`);
+  });
+});
+
+describe('sanitizeRef', () => {
+  it('removes forbidden characters', () => expect(sanitizeRef(['feat', 'abc$', '%de*f'], '/')).toBe('feat/abc/def'));
+  it('replaces dots following slashes with dot-', () => expect(sanitizeRef(['fix', '.way'], '/')).toBe('fix/dot-way'));
+  it('squeezes multiple slashes', () => expect(sanitizeRef(['a//b', 'c', 'd'], '/')).toBe('a/b/c/d'));
+  it('squeezes multiple periods', () => expect(sanitizeRef(['a..b', 'c..d'], '/')).toBe('a.b/c.d'));
+  it('squeezes multiple slashes and periods', () => expect(sanitizeRef(['a//b..c', '', 'd'], '/')).toBe('a/b.c/d'));
+  it('removes trailing period', () => expect(sanitizeRef(['release', 'v1.0.0.'], '/')).toBe('release/v1.0.0'));
+  it('handles all steps', () => expect(sanitizeRef(['a//b..c', '', '.d', '1.1.'], '/')).toBe('a/b.c/dot-d/1.1'));
+});


### PR DESCRIPTION
When the branch name separator is not a slash, the directory needs to be normalized to respect that.

This also adds tests for `branch-name.ts` and as a result remove unnecessary escapes in RegEx.