### PR TITLE
Add `dryRun` input to replace `skipPullRequests`

### DIFF
--- a/extensions/azure/README.md
+++ b/extensions/azure/README.md
@@ -55,7 +55,7 @@ Dependabot uses Docker containers, which may take time to install if not already
 
 |Input|Description|
 |--|--|
-|skipPullRequests|**_Optional_**. Determines whether to skip creation and updating of pull requests. When set to `true` the logic to update the dependencies is executed but the actual Pull Requests are not created/updated. This is useful for debugging. Defaults to `false`.|
+|dryRun|**_Optional_**. Test logic without actually creating, updating or abandoning pull requests. When set to `true` the logic to update the dependencies is executed but the actual Pull Requests are not created/updated/abandoned. This is useful for debugging. Defaults to `false`.|
 |setAutoComplete|**_Optional_**. Determines if the pull requests that dependabot creates should have auto complete set. When set to `true`, pull requests that pass all policies will be merged automatically. Defaults to `false`.|
 |mergeStrategy|**_Optional_**. The merge strategy to use when auto complete is set. Learn more [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/git/pull-requests/update?view=azure-devops-rest-6.0&tabs=HTTP#gitpullrequestmergestrategy). Defaults to `squash`.|
 |autoCompleteIgnoreConfigIds|**_Optional_**. List of any policy configuration Id's which auto-complete should not wait for. Only applies to optional policies. Auto-complete always waits for required (blocking) policies.|

--- a/extensions/azure/src/dependabot/output-processor.ts
+++ b/extensions/azure/src/dependabot/output-processor.ts
@@ -103,8 +103,8 @@ export class DependabotOutputProcessor {
       }
       case 'create_pull_request': {
         const title = data['pr-title'];
-        if (this.taskInputs.skipPullRequests) {
-          warning(`Skipping pull request creation of '${title}' as 'skipPullRequests' is set to 'true'`);
+        if (this.taskInputs.dryRun) {
+          warning(`Skipping pull request creation of '${title}' as 'dryRun' is set to 'true'`);
           return true;
         }
 
@@ -210,8 +210,8 @@ export class DependabotOutputProcessor {
       }
 
       case 'update_pull_request': {
-        if (this.taskInputs.skipPullRequests) {
-          warning(`Skipping pull request update as 'skipPullRequests' is set to 'true'`);
+        if (this.taskInputs.dryRun) {
+          warning(`Skipping pull request update as 'dryRun' is set to 'true'`);
           return true;
         }
 
@@ -254,8 +254,8 @@ export class DependabotOutputProcessor {
       }
 
       case 'close_pull_request': {
-        if (this.taskInputs.skipPullRequests) {
-          warning(`Skipping pull request closure as 'skipPullRequests' is set to 'true'`);
+        if (this.taskInputs.dryRun) {
+          warning(`Skipping pull request closure as 'dryRun' is set to 'true'`);
           return true;
         }
 

--- a/extensions/azure/src/task-v2.ts
+++ b/extensions/azure/src/task-v2.ts
@@ -203,8 +203,8 @@ export async function abandonPullRequestsWhereSourceRefIsDeleted(
       pullRequest.properties?.find((x) => x.name === DEVOPS_PR_PROPERTY_MICROSOFT_GIT_SOURCE_REF_NAME)?.value,
     );
     if (pullRequestSourceRefName && !existingBranchNames.includes(pullRequestSourceRefName)) {
-      // The source branch for the pull request has been deleted; abandon the pull request (if manipulation is allowed)
-      if (!taskInputs.skipPullRequests) {
+      // The source branch for the pull request has been deleted; abandon the pull request (if not dry run)
+      if (!taskInputs.dryRun) {
         warning(
           `Detected source branch for PR #${pullRequest.id} has been deleted; The pull request will be abandoned`,
         );
@@ -357,7 +357,7 @@ export async function performDependabotUpdatesAsync(
     // If there are existing pull requests, run an update job for each one; this will resolve merge conflicts and close pull requests that are no longer needed
     const numberOfPullRequestsToUpdate = Object.keys(existingPullRequestsForPackageManager).length;
     if (numberOfPullRequestsToUpdate > 0) {
-      if (!taskInputs.skipPullRequests) {
+      if (!taskInputs.dryRun) {
         for (const pullRequestId in existingPullRequestsForPackageManager) {
           const outputs = await dependabotCli.update(
             DependabotJobBuilder.updatePullRequestJob(
@@ -376,7 +376,7 @@ export async function performDependabotUpdatesAsync(
         }
       } else {
         warning(
-          `Skipping update of ${numberOfPullRequestsToUpdate} existing ${packageEcosystem} package pull request(s) as 'skipPullRequests' is set to 'true'`,
+          `Skipping update of ${numberOfPullRequestsToUpdate} existing ${packageEcosystem} package pull request(s) as 'dryRun' is set to 'true'`,
         );
       }
     }

--- a/extensions/azure/src/utils/shared-variables.ts
+++ b/extensions/azure/src/utils/shared-variables.ts
@@ -63,8 +63,8 @@ export interface ISharedVariables {
 
   securityAdvisoriesFile: string | undefined;
 
-  /** Determines whether to skip creating/updating pull requests */
-  skipPullRequests: boolean;
+  /** Whether to test logic without creating, updating or abandoning pull requests */
+  dryRun: boolean;
 
   /** The dependabot-cli go package to use for updates. e.g. github.com/dependabot/cli/cmd/dependabot@latest */
   dependabotCliPackage?: string;
@@ -175,7 +175,15 @@ export default function getSharedVariables(): ISharedVariables {
 
   // Prepare other variables
   const securityAdvisoriesFile: string | undefined = tl.getInput('securityAdvisoriesFile');
+  let dryRun: boolean = tl.getBoolInput('dryRun', false);
+  // TODO: remove skipPullRequests input after 2025-07-01
   const skipPullRequests: boolean = tl.getBoolInput('skipPullRequests', false);
+  if (skipPullRequests) {
+    tl.warning(
+      'The skipPullRequests input is deprecated. Use the dryRun input instead. It shall be removed on or after 2025-07-01.',
+    );
+    dryRun = true;
+  }
 
   const dependabotCliPackage: string | undefined = tl.getInput('dependabotCliPackage');
   const dependabotCliApiUrl: string | undefined = tl.getInput('dependabotCliApiUrl', false);
@@ -221,7 +229,7 @@ export default function getSharedVariables(): ISharedVariables {
     targetUpdateIds,
     securityAdvisoriesFile,
 
-    skipPullRequests,
+    dryRun,
 
     dependabotCliPackage,
     dependabotCliApiUrl,

--- a/extensions/azure/tasks/dependabotV2/task.json
+++ b/extensions/azure/tasks/dependabotV2/task.json
@@ -57,6 +57,14 @@
       "helpMarkDown": "When set to `true` the logic to update the dependencies is executed but the actual Pull Requests are not created/updated. Defaults to `false`."
     },
     {
+      "name": "dryRun",
+      "type": "boolean",
+      "label": "Test logic without actually creating, updating or abandoning pull requests.",
+      "defaultValue": false,
+      "required": false,
+      "helpMarkDown": "When set to `true` the logic to update the dependencies is executed but the actual Pull Requests are not created/updated/abandoned. This is useful for debugging. Defaults to `false`."
+    },
+    {
       "name": "setAutoComplete",
       "type": "boolean",
       "groupName": "pull_requests",

--- a/extensions/azure/tests/dependabot/output-processor.test.ts
+++ b/extensions/azure/tests/dependabot/output-processor.test.ts
@@ -76,8 +76,8 @@ describe('DependabotOutputProcessor', () => {
       expect(result).toBe(true);
     });
 
-    it('should skip processing "create_pull_request" if "skipPullRequests" is true', async () => {
-      taskInputs.skipPullRequests = true;
+    it('should skip processing "create_pull_request" if "dryRun" is true', async () => {
+      taskInputs.dryRun = true;
 
       const result = await processor.process(update, 'create_pull_request', data);
 
@@ -116,8 +116,8 @@ describe('DependabotOutputProcessor', () => {
       expect(prApproverClient.approvePullRequest).toHaveBeenCalled();
     });
 
-    it('should skip processing "update_pull_request" if "skipPullRequests" is false', async () => {
-      taskInputs.skipPullRequests = true;
+    it('should skip processing "update_pull_request" if "dryRun" is false', async () => {
+      taskInputs.dryRun = true;
 
       const result = await processor.process(update, 'update_pull_request', data);
 
@@ -167,8 +167,8 @@ describe('DependabotOutputProcessor', () => {
       expect(prApproverClient.approvePullRequest).toHaveBeenCalled();
     });
 
-    it('should skip processing "close_pull_request" if "skipPullRequests" is true', async () => {
-      taskInputs.skipPullRequests = true;
+    it('should skip processing "close_pull_request" if "dryRun" is true', async () => {
+      taskInputs.dryRun = true;
 
       const result = await processor.process(update, 'close_pull_request', data);
 
@@ -177,7 +177,7 @@ describe('DependabotOutputProcessor', () => {
     });
 
     it('should fail processing "close_pull_request" if pull request does not exist', async () => {
-      taskInputs.skipPullRequests = false;
+      taskInputs.dryRun = false;
       data = {
         'dependency-names': ['dependency1'],
       };
@@ -189,7 +189,7 @@ describe('DependabotOutputProcessor', () => {
     });
 
     it('should process "close_pull_request"', async () => {
-      taskInputs.skipPullRequests = false;
+      taskInputs.dryRun = false;
       update.job['package-manager'] = 'npm';
       data = {
         'dependency-names': ['dependency1'],

--- a/extensions/azure/tests/task-v2.test.ts
+++ b/extensions/azure/tests/task-v2.test.ts
@@ -30,7 +30,7 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     taskInputs = {
-      skipPullRequests: false,
+      dryRun: false,
     } as ISharedVariables;
     devOpsPrAuthorClient = new AzureDevOpsWebApiClient('https://dev.azure.com/test-org', 'fake-token', true);
     devOpsPrAuthorClient.abandonPullRequest = vi.fn().mockResolvedValue(true);
@@ -65,8 +65,8 @@ describe('abandonPullRequestsWhereSourceRefIsDeleted', () => {
     });
   });
 
-  it('should not abandon pull requests when `skipPullRequests` is true', async () => {
-    taskInputs.skipPullRequests = true;
+  it('should not abandon pull requests when `dryRun` is true', async () => {
+    taskInputs.dryRun = true;
 
     await abandonPullRequestsWhereSourceRefIsDeleted(
       taskInputs,


### PR DESCRIPTION
This is better naming and will allow testing other logic besides pull requests later.

`skipPullRequests` will continue to be present for another month.