### PR TITLE
Update default experiments as of 09 June 2025

### DIFF
--- a/.changeset/heavy-papayas-brush.md
+++ b/.changeset/heavy-papayas-brush.md
@@ -1,0 +1,5 @@
+---
+'@paklo/core': patch
+---
+
+Update default experiments as of 09 June 2025

--- a/packages/core/src/dependabot/experiments.ts
+++ b/packages/core/src/dependabot/experiments.ts
@@ -13,7 +13,6 @@ export const DEFAULT_EXPERIMENTS: DependabotExperiments = {
   'nuget-native-analysis': true,
   'nuget-native-updater': true,
   'nuget-use-direct-discovery': true,
-  'nuget-use-legacy-updater-when-updating-pr': true,
   'enable-file-parser-python-local': true,
   'npm-fallback-version-above-v6': true,
   'lead-security-dependency': true,
@@ -37,4 +36,6 @@ export const DEFAULT_EXPERIMENTS: DependabotExperiments = {
   'enable-cooldown-metrics-collection': true,
   'enable-cooldown-for-composer': true,
   'enable-cooldown-for-gradle': true,
+  'enable-cooldown-for-pub': true,
+  'enable-cooldown-for-gitsubmodules': true,
 };


### PR DESCRIPTION
As observed at https://github.com/mburumaxwell/dependabot-azure-devops/actions/runs/15529132614/job/43714190436