### PR TITLE
Set `multi-ecosystem-update` in job config

### DIFF
--- a/.changeset/legal-beers-roll.md
+++ b/.changeset/legal-beers-roll.md
@@ -1,0 +1,6 @@
+---
+'extension-azure-devops': patch
+'@paklo/core': patch
+---
+
+Set `multi-ecosystem-update` in job config

--- a/extensions/azure/src/dependabot/job-builder.ts
+++ b/extensions/azure/src/dependabot/job-builder.ts
@@ -175,6 +175,12 @@ export function buildUpdateJobConfig(
       'proxy-log-response-body-on-auth-failure': true,
       'max-updater-run-time': 2700,
       'enable-beta-ecosystems': enableBetaEcosystems || false,
+      // Updates across ecosystems is still in development
+      // See https://github.com/dependabot/dependabot-core/issues/8126
+      //     https://github.com/dependabot/dependabot-core/pull/12339
+      // It needs to merged in the core repo first before we support it
+      // However, to match current job configs and to prevent surprises, we disable it
+      'multi-ecosystem-update': false,
     },
     credentials,
   };

--- a/packages/core/src/dependabot/job.ts
+++ b/packages/core/src/dependabot/job.ts
@@ -162,6 +162,7 @@ export const DependabotJobConfigSchema = z.object({
   'cooldown': DependabotCooldownSchema.nullish(),
   'proxy-log-response-body-on-auth-failure': z.boolean().nullish(),
   'enable-beta-ecosystems': z.boolean().nullish(),
+  'multi-ecosystem-update': z.boolean().nullish(),
 });
 export type DependabotJobConfig = z.infer<typeof DependabotJobConfigSchema>;
 


### PR DESCRIPTION
Updates across ecosystems is still in development. It needs to merged in the core repo first before we support it. However, to match current job configs and to prevent surprises, we disable it.