### PR TITLE
Replace ||= with ??= to preserve falsy values in default assignment

### DIFF
--- a/.changeset/cute-rooms-eat.md
+++ b/.changeset/cute-rooms-eat.md
@@ -1,0 +1,6 @@
+---
+'extension-azure-devops': patch
+'paklo': patch
+---
+
+Replace ||= with ??= to preserve falsy values in default assignment

--- a/extensions/azure/scripts/update-versions.mjs
+++ b/extensions/azure/scripts/update-versions.mjs
@@ -12,7 +12,7 @@ async function updateTaskJsonFiles({ cwd, dev, version, buildNumber }) {
 
   for (const fileName of fileNames) {
     const contents = JSON.parse(await readFile(fileName, 'utf-8'));
-    const cv = (contents.version ||= {});
+    const cv = (contents.version ??= {});
     const current = `${cv.Major}.${cv.Minor}.${cv.Patch}`;
     // we do not update the Major version because ideally it would be a different task
     // contents.version.Major = version.major;

--- a/extensions/azure/src/azure-devops/client.ts
+++ b/extensions/azure/src/azure-devops/client.ts
@@ -46,7 +46,7 @@ export class AzureDevOpsWebApiClient {
    * @returns
    */
   public async getUserId(): Promise<string> {
-    this.authenticatedUserId ||= (await this.connection.connect()).authenticatedUser!.id!;
+    this.authenticatedUserId ??= (await this.connection.connect()).authenticatedUser!.id!;
     return this.authenticatedUserId;
   }
 
@@ -556,7 +556,7 @@ export class AzureDevOpsWebApiClient {
     params?: Record<string, string>,
     apiVersion: string = AzureDevOpsWebApiClient.API_VERSION,
   ) {
-    params ||= {};
+    params ??= {};
     const queryString = Object.keys(params)
       .map((key) => `${key}=${params[key]}`)
       .join('&');

--- a/extensions/azure/src/dependabot/cli.ts
+++ b/extensions/azure/src/dependabot/cli.ts
@@ -189,7 +189,7 @@ export class DependabotCli {
   // Get the dependabot tool path and install if missing
   private async getDependabotToolPath(installIfMissing: boolean = true): Promise<string> {
     debug('Checking for `dependabot` install...');
-    this.toolPath ||= which('dependabot', false);
+    this.toolPath ??= which('dependabot', false);
     if (this.toolPath) {
       return this.toolPath;
     }
@@ -207,7 +207,7 @@ export class DependabotCli {
     // If dependabot still cannot be found using `which()` after install, we must manually resolve the path;
     // It will either be "$GOPATH/bin/dependabot" or "$HOME/go/bin/dependabot", if GOPATH is not set.
     const goBinPath = process.env.GOPATH ? path.join(process.env.GOPATH, 'bin') : path.join(os.homedir(), 'go', 'bin');
-    return (this.toolPath ||= which('dependabot', false) || path.join(goBinPath, 'dependabot'));
+    return (this.toolPath ??= which('dependabot', false) || path.join(goBinPath, 'dependabot'));
   }
 
   // Create the jobs directory if it does not exist

--- a/extensions/azure/src/dependabot/job-builder.ts
+++ b/extensions/azure/src/dependabot/job-builder.ts
@@ -350,7 +350,7 @@ export function mapCredentials(
 }
 
 export function mapExperiments(experiments?: DependabotExperiments): DependabotExperiments {
-  experiments ||= {};
+  experiments ??= {};
   return Object.keys(experiments).reduce((acc, key) => {
     // Experiment values are known to be either 'true', 'false', or a string value.
     // If the value is 'true' or 'false', convert it to a boolean type so that dependabot-core handles it correctly.

--- a/packages/paklo/fixtures/config/dependabot.yml
+++ b/packages/paklo/fixtures/config/dependabot.yml
@@ -35,6 +35,11 @@ updates:
         update-types:
           - 'minor'
           - 'patch'
+  - package-ecosystem: 'devcontainers' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    open-pull-requests-limit: 0
+  - package-ecosystem: 'dotnet-sdk' # See documentation for possible values
+    directory: '/' # Location of package manifests
 registries:
   reg1:
     type: nuget-feed

--- a/packages/paklo/src/dependabot/config.test.ts
+++ b/packages/paklo/src/dependabot/config.test.ts
@@ -17,7 +17,7 @@ describe('Parse configuration file', () => {
       yaml.load(await readFile('fixtures/config/dependabot.yml', 'utf-8')),
     );
     const updates = parseUpdates(config, '');
-    expect(updates.length).toBe(3);
+    expect(updates.length).toBe(5);
 
     // first
     const first = updates[0]!;
@@ -43,6 +43,22 @@ describe('Parse configuration file', () => {
     expect(JSON.stringify(third.groups)).toBe(
       '{"microsoft":{"patterns":["microsoft*"],"update-types":["minor","patch"]}}',
     );
+
+    // fourth
+    const fourth = updates[3]!;
+    expect(fourth.directory).toBe('/');
+    expect(fourth.directories).toBeUndefined();
+    expect(fourth['package-ecosystem']).toBe('devcontainers');
+    expect(fourth['open-pull-requests-limit']).toEqual(0);
+    expect(fourth.registries).toBeUndefined();
+
+    // fifth
+    const fifth = updates[4]!;
+    expect(fifth.directory).toBe('/');
+    expect(fifth.directories).toBeUndefined();
+    expect(fifth['package-ecosystem']).toBe('dotnet-sdk');
+    expect(fifth['open-pull-requests-limit']).toEqual(5);
+    expect(fifth.registries).toBeUndefined();
   });
 });
 

--- a/packages/paklo/src/dependabot/config.ts
+++ b/packages/paklo/src/dependabot/config.ts
@@ -195,7 +195,7 @@ export const DependabotUpdateSchema = z
       addIssue("Either 'directory' or 'directories' must be specified in the dependency update configuration.");
     }
 
-    value['open-pull-requests-limit'] ||= 5; // default to 5 if not specified
+    value['open-pull-requests-limit'] ??= 5; // default to 5 if not specified
 
     return value;
   });
@@ -272,9 +272,9 @@ export function parseUpdates(config: DependabotConfig, configPath: string): Depe
     //       Currently they don't appear to add much value to the update process, but are populated here for completeness.
     if (update.ignore) {
       for (const condition of update.ignore) {
-        condition['source'] ||= configPath;
+        condition['source'] ??= configPath;
         // we don't know the last updated time, so we use the current time
-        condition['updated-at'] ||= new Date().toISOString();
+        condition['updated-at'] ??= new Date().toISOString();
       }
     }
 


### PR DESCRIPTION
The `||=` operator treats falsy values like `0`, `false`, and `''` as unset, which led to unintended overwrites. Switching to `??=` ensures only null or undefined trigger the default assignment.

Fixes: #1778 