### PR TITLE
Collect affected PRs for a given run and set output variable

### DIFF
--- a/.changeset/small-bats-lead.md
+++ b/.changeset/small-bats-lead.md
@@ -1,0 +1,5 @@
+---
+'extension-azure-devops': minor
+---
+
+Collect affected PRs for a given run and set output variable

--- a/extensions/azure/src/dependabot/cli.ts
+++ b/extensions/azure/src/dependabot/cli.ts
@@ -166,7 +166,9 @@ export class DependabotCli {
             // https://github.com/dependabot/cli/blob/main/internal/model/scenario.go
             const operationResult: IDependabotUpdateOperationResult = { success: true, output };
             try {
-              operationResult.success = await this.outputProcessor.process(operation, output);
+              const { success, pr } = await this.outputProcessor.process(operation, output);
+              operationResult.success = success;
+              operationResult.pr = pr;
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
             } catch (e: any) {
               operationResult.success = false;

--- a/extensions/azure/src/dependabot/models.ts
+++ b/extensions/azure/src/dependabot/models.ts
@@ -14,4 +14,5 @@ export type IDependabotUpdateOperationResult = {
   success: boolean;
   error?: Error;
   output: DependabotOutput;
+  pr?: number;
 };

--- a/extensions/azure/tasks/dependabotV2/task.json
+++ b/extensions/azure/tasks/dependabotV2/task.json
@@ -258,6 +258,12 @@
       "helpMarkDown": "Comma-seperated list of key/value pairs representing the enabled Dependabot experiments e.g. `experiments: 'tidy=true,vendor=true,goprivate=*'`. Available options vary depending on the package ecosystem. If specified, this overrides the [default experiments](https://github.com/tinglesoftware/dependabot-azure-devops/blob/main/packages/core/src/dependabot/experiments.ts). See [configuring experiments](https://github.com/tinglesoftware/dependabot-azure-devops/#configuring-experiments) for more details."
     }
   ],
+  "outputVariables": [
+    {
+      "name": "affectedPrs",
+      "description": "Comma-separated values of identifiers for pull requests modified (created/modified/abandoned). For example: `1341,903`."
+    }
+  ],
   "execution": {
     "Node20_1": {
       "target": "dist/task-v2.js"

--- a/extensions/azure/tests/dependabot/output-processor.test.ts
+++ b/extensions/azure/tests/dependabot/output-processor.test.ts
@@ -74,7 +74,7 @@ describe('DependabotOutputProcessor', () => {
         },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
     });
 
     it('should skip processing "create_pull_request" if "dryRun" is true', async () => {
@@ -94,7 +94,7 @@ describe('DependabotOutputProcessor', () => {
         },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
       expect(prAuthorClient.createPullRequest).not.toHaveBeenCalled();
     });
 
@@ -115,14 +115,14 @@ describe('DependabotOutputProcessor', () => {
         },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
       expect(prAuthorClient.createPullRequest).not.toHaveBeenCalled();
     });
 
     it('should process "create_pull_request"', async () => {
       taskInputs.autoApprove = true;
 
-      prAuthorClient.createPullRequest = vi.fn().mockResolvedValue(1);
+      prAuthorClient.createPullRequest = vi.fn().mockResolvedValue(11);
       prAuthorClient.getDefaultBranch = vi.fn().mockResolvedValue('main');
       prApproverClient.approvePullRequest = vi.fn().mockResolvedValue(true);
 
@@ -140,7 +140,7 @@ describe('DependabotOutputProcessor', () => {
         },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true, pr: 11 });
       expect(prAuthorClient.createPullRequest).toHaveBeenCalled();
       expect(prApproverClient.approvePullRequest).toHaveBeenCalled();
     });
@@ -162,7 +162,7 @@ describe('DependabotOutputProcessor', () => {
         },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
       expect(prAuthorClient.updatePullRequest).not.toHaveBeenCalled();
     });
 
@@ -181,7 +181,7 @@ describe('DependabotOutputProcessor', () => {
         },
       });
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ success: false });
       expect(prAuthorClient.updatePullRequest).not.toHaveBeenCalled();
     });
 
@@ -190,7 +190,7 @@ describe('DependabotOutputProcessor', () => {
       update.job['package-manager'] = 'npm_and_yarn';
 
       existingPullRequests.push({
-        id: 1,
+        id: 11,
         properties: [
           { name: DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'npm_and_yarn' },
           {
@@ -217,7 +217,7 @@ describe('DependabotOutputProcessor', () => {
         },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true, pr: 11 });
       expect(prAuthorClient.updatePullRequest).toHaveBeenCalled();
       expect(prApproverClient.approvePullRequest).toHaveBeenCalled();
     });
@@ -230,7 +230,7 @@ describe('DependabotOutputProcessor', () => {
         expect: { data: { 'dependency-names': [] } },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
       expect(prAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
     });
 
@@ -242,7 +242,7 @@ describe('DependabotOutputProcessor', () => {
         expect: { data: { 'dependency-names': ['dependency1'] } },
       });
 
-      expect(result).toBe(false);
+      expect(result).toEqual({ success: false });
       expect(prAuthorClient.abandonPullRequest).not.toHaveBeenCalled();
     });
 
@@ -250,7 +250,7 @@ describe('DependabotOutputProcessor', () => {
       taskInputs.dryRun = false;
       update.job['package-manager'] = 'npm_and_yarn';
       existingPullRequests.push({
-        id: 1,
+        id: 11,
         properties: [
           { name: DEVOPS_PR_PROPERTY_DEPENDABOT_PACKAGE_MANAGER, value: 'npm_and_yarn' },
           {
@@ -267,18 +267,18 @@ describe('DependabotOutputProcessor', () => {
         expect: { data: { 'dependency-names': ['dependency1'] } },
       });
 
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true, pr: 11 });
       expect(prAuthorClient.abandonPullRequest).toHaveBeenCalled();
     });
 
     it('should process "mark_as_processed"', async () => {
       const result = await processor.process(update, { type: 'mark_as_processed', expect: { data: {} } });
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
     });
 
     it('should process "record_ecosystem_versions"', async () => {
       const result = await processor.process(update, { type: 'record_ecosystem_versions', expect: { data: {} } });
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
     });
 
     it('should process "record_ecosystem_meta"', async () => {
@@ -286,7 +286,7 @@ describe('DependabotOutputProcessor', () => {
         type: 'record_ecosystem_meta',
         expect: { data: [{ ecosystem: { name: 'npm_any_yarn' } }] },
       });
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
     });
 
     it('should process "record_update_job_error"', async () => {
@@ -294,7 +294,7 @@ describe('DependabotOutputProcessor', () => {
         type: 'record_update_job_error',
         expect: { data: { 'error-type': 'random' } },
       });
-      expect(result).toBe(false);
+      expect(result).toEqual({ success: false });
       expect(error).toHaveBeenCalled();
     });
 
@@ -303,8 +303,7 @@ describe('DependabotOutputProcessor', () => {
         type: 'record_update_job_unknown_error',
         expect: { data: { 'error-type': 'random' } },
       });
-
-      expect(result).toBe(false);
+      expect(result).toEqual({ success: false });
       expect(error).toHaveBeenCalled();
     });
 
@@ -313,15 +312,13 @@ describe('DependabotOutputProcessor', () => {
         type: 'increment_metric',
         expect: { data: { metric: 'random' } },
       });
-
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
     });
 
     it('should handle unknown output type', async () => {
       // @ts-expect-error - trying non existed type
       const result = await processor.process(update, { type: 'non_existant_output_type', expect: { data: {} } });
-
-      expect(result).toBe(true);
+      expect(result).toEqual({ success: true });
       expect(warning).toHaveBeenCalled();
     });
   });

--- a/extensions/azure/tests/task-v2.test.ts
+++ b/extensions/azure/tests/task-v2.test.ts
@@ -182,7 +182,7 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.Succeeded);
+    expect(updateResult).toEqual({ result: TaskResult.Succeeded, prs: [] });
     expect(dependabotCli.update).toHaveBeenCalled();
     expect(DependabotJobBuilder.updateAllDependenciesJob).toHaveBeenCalled();
   });
@@ -215,7 +215,7 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.Succeeded);
+    expect(updateResult).toEqual({ result: TaskResult.Succeeded, prs: [] });
     expect(DependabotJobBuilder.updateAllDependenciesJob).not.toHaveBeenCalled();
   });
 
@@ -233,7 +233,7 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.Succeeded);
+    expect(updateResult).toEqual({ result: TaskResult.Succeeded, prs: [] });
     expect(DependabotJobBuilder.listAllDependenciesJob).toHaveBeenCalled();
   });
 
@@ -265,7 +265,7 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.Succeeded);
+    expect(updateResult).toEqual({ result: TaskResult.Succeeded, prs: [] });
     expect(DependabotJobBuilder.updatePullRequestJob).toHaveBeenCalled();
   });
 
@@ -283,7 +283,7 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.Succeeded);
+    expect(updateResult).toEqual({ result: TaskResult.Succeeded, prs: [] });
   });
 
   it('should return SucceededWithIssues result when updates are mixture of success and failure', async () => {
@@ -301,7 +301,7 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.SucceededWithIssues);
+    expect(updateResult).toEqual({ result: TaskResult.SucceededWithIssues, prs: [] });
   });
 
   it('should return Failed result when all updates are failure', async () => {
@@ -318,7 +318,7 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.Failed);
+    expect(updateResult).toEqual({ result: TaskResult.Failed, prs: [] });
   });
 
   it('should return Skipped result when no updates are performed', async () => {
@@ -333,6 +333,25 @@ describe('performDependabotUpdatesAsync', () => {
       existingPullRequests,
     );
 
-    expect(updateResult).toBe(TaskResult.Skipped);
+    expect(updateResult).toEqual({ result: TaskResult.Skipped, prs: [] });
+  });
+
+  it('should collect PRs', async () => {
+    dependabotCli.update = vi.fn().mockResolvedValue([
+      { success: true, output: {}, pr: 501 },
+      { success: true, output: {}, pr: 501 },
+      { success: true, output: {}, pr: 521 },
+    ] as IDependabotUpdateOperationResult[]);
+
+    const updateResult = await performDependabotUpdatesAsync(
+      taskInputs,
+      dependabotConfig,
+      dependabotConfig.updates,
+      dependabotCli,
+      dependabotCliUpdateOptions,
+      existingPullRequests,
+    );
+
+    expect(updateResult).toEqual({ result: TaskResult.Succeeded, prs: [501, 521] });
   });
 });


### PR DESCRIPTION
To allow other tasks to be chained to be placed after dependabot runs, it makes sense to collect the identifiers of pull requests created/modified/abandoned then output these. This change introduces a comma-separated value is set to a new `affectedPrs` output variable.

It should not be easier to do any other logic that one needs to do such as making reviewers required, sending notifications to Teams, or light up some office lights.