### PR TITLE
Update default experiments as of 16 June 2025

### DIFF
--- a/.changeset/giant-papers-walk.md
+++ b/.changeset/giant-papers-walk.md
@@ -1,0 +1,5 @@
+---
+'paklo': patch
+---
+
+Update default experiments as of 16 June 2025

--- a/packages/paklo/src/dependabot/experiments.ts
+++ b/packages/paklo/src/dependabot/experiments.ts
@@ -38,4 +38,5 @@ export const DEFAULT_EXPERIMENTS: DependabotExperiments = {
   'enable-cooldown-for-gradle': true,
   'enable-cooldown-for-pub': true,
   'enable-cooldown-for-gitsubmodules': true,
+  'enable-cooldown-for-elm': true,
 };


### PR DESCRIPTION
As observed at https://github.com/mburumaxwell/dependabot-azure-devops/actions/runs/15680825245/job/44171623818