### PR TITLE
Use System.DefaultWorkingDirectory as fallback in release pipelines

### DIFF
--- a/extensions/azure/src/task-v2.ts
+++ b/extensions/azure/src/task-v2.ts
@@ -75,7 +75,7 @@ async function run() {
     const dependabotConfig = await getDependabotConfig({
       url: taskInputs.url,
       token: taskInputs.systemAccessToken,
-      rootDir: getVariable('Build.SourcesDirectory')!,
+      rootDir: getVariable('Build.SourcesDirectory') ?? getVariable('System.DefaultWorkingDirectory')!,
       variableFinder: getVariable,
     });
     if (!dependabotConfig) {


### PR DESCRIPTION
This fixes #1943

The issue is that I am using release pipelines to run Dependabot. It provides a certain freedom in running Dependabot pipelines.

It can be improved, but it currently works.

Workaround:
<img width="1897" height="760" alt="image" src="https://github.com/user-attachments/assets/99ba807b-4c3f-4949-93b1-9f4768d9e28b" />
