### PR TITLE
Add tool usage tracking

### DIFF
--- a/.changeset/puny-seals-send.md
+++ b/.changeset/puny-seals-send.md
@@ -1,0 +1,9 @@
+---
+"@paklo/cli": minor
+---
+
+Add tool usage tracking.
+The information collected is shown in the logs at the end of each job.
+
+This is to help me understand the usage of the tool/extension/cli through a couple of weeks. There is no other source of this information except for when reviews are left but no-one is bothered to leave those or to even want to give feedback via other channels.
+Do people still use this? Let's find out.

--- a/apps/dashboard/prisma/migrations/20251003142314_usage_telemetry/migration.sql
+++ b/apps/dashboard/prisma/migrations/20251003142314_usage_telemetry/migration.sql
@@ -1,0 +1,24 @@
+-- CreateEnum
+CREATE TYPE "public"."job_trigger" AS ENUM ('user', 'service');
+
+-- CreateEnum
+CREATE TYPE "public"."source_provider" AS ENUM ('azure');
+
+-- CreateTable
+CREATE TABLE "public"."usage_telemetry" (
+    "id" BIGINT NOT NULL,
+    "hostPlatform" TEXT NOT NULL,
+    "hostRelease" TEXT NOT NULL,
+    "hostArch" TEXT NOT NULL,
+    "hostMachineHash" TEXT NOT NULL,
+    "version" TEXT NOT NULL,
+    "trigger" "public"."job_trigger" NOT NULL,
+    "provider" "public"."source_provider" NOT NULL,
+    "owner" TEXT NOT NULL,
+    "packageManager" TEXT NOT NULL,
+    "started" TIMESTAMP(3) NOT NULL,
+    "duration" INTEGER NOT NULL,
+    "success" BOOLEAN NOT NULL,
+
+    CONSTRAINT "usage_telemetry_pkey" PRIMARY KEY ("id")
+);

--- a/apps/dashboard/prisma/schema.prisma
+++ b/apps/dashboard/prisma/schema.prisma
@@ -13,6 +13,37 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum JobTrigger {
+  user
+  service
+
+  @@map("job_trigger")
+}
+
+enum SourceProvider {
+  azure
+
+  @@map("source_provider")
+}
+
+model UsageTelemetry {
+  id                BigInt         @id
+  hostPlatform      String
+  hostRelease       String
+  hostArch          String
+  hostMachineHash   String
+  version           String
+  trigger           JobTrigger
+  provider          SourceProvider
+  owner             String
+  packageManager    String
+  started           DateTime
+  duration          Int
+  success           Boolean
+
+  @@map("usage_telemetry")
+}
+
 model User {
   id            String       @id
   name          String

--- a/apps/dashboard/src/app/api/cleanup/usage-telemetry/route.ts
+++ b/apps/dashboard/src/app/api/cleanup/usage-telemetry/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
+import { prisma } from '@/lib/prisma';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  // Delete records older than 1 year
+  const oneYearAgo = new Date();
+  oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+  const result = await prisma.usageTelemetry.deleteMany({
+    where: { started: { lt: oneYearAgo } },
+  });
+
+  logger.info(
+    `Usage telemetry cleanup completed: deleted ${result.count} records older than ${oneYearAgo.toISOString()}`,
+  );
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/dashboard/src/app/api/usage-telemetry/route.ts
+++ b/apps/dashboard/src/app/api/usage-telemetry/route.ts
@@ -1,0 +1,42 @@
+import { zValidator } from '@hono/zod-validator';
+import { UsageTelemetryRequestDataSchema } from '@paklo/cli/dependabot';
+import { Hono } from 'hono';
+import { handle } from 'hono/vercel';
+
+import { prisma } from '@/lib/prisma';
+import type { UsageTelemetry } from '@/lib/prisma/client';
+
+export const dynamic = 'force-dynamic';
+
+const app = new Hono().basePath('/api/usage-telemetry');
+
+app.post('/', zValidator('json', UsageTelemetryRequestDataSchema), async (context) => {
+  const payload = context.req.valid('json');
+
+  const { id } = payload;
+
+  const values: Omit<UsageTelemetry, 'id'> = {
+    hostPlatform: payload.host.platform,
+    hostRelease: payload.host.release,
+    hostArch: payload.host.arch,
+    hostMachineHash: payload.host['machine-hash'],
+    trigger: payload.trigger,
+    version: payload.version,
+    provider: payload.provider,
+    owner: payload.owner,
+    packageManager: payload['package-manager'],
+    started: payload.started,
+    duration: payload.duration,
+    success: payload.success,
+  };
+
+  await prisma.usageTelemetry.upsert({
+    where: { id },
+    create: { id: payload.id, ...values },
+    update: { ...values },
+  });
+
+  return context.body(null, 204);
+});
+
+export const POST = handle(app);

--- a/apps/dashboard/src/lib/prisma/client.ts
+++ b/apps/dashboard/src/lib/prisma/client.ts
@@ -5,6 +5,8 @@ export type {
   Organization,
   Passkey,
   Session,
+  SourceProvider,
+  UsageTelemetry,
   User,
   Verification,
 } from '@prisma/client';

--- a/apps/dashboard/src/middleware.ts
+++ b/apps/dashboard/src/middleware.ts
@@ -20,11 +20,12 @@ export const config = {
     /*
      * Match all paths except for:
      * 1. /api/update_jobs/ routes
-     * 2. /_next/ (Next.js internals)
-     * 3. /_static (inside /public)
-     * 4. /_vercel (Vercel internals)
-     * 5. Static files (e.g. /favicon.ico, /sitemap.xml, /robots.txt, etc.)
+     * 2. /api/usage-telemetry (public usage telemetry endpoint)
+     * 3. /_next/ (Next.js internals)
+     * 4. /_static (inside /public)
+     * 5. /_vercel (Vercel internals)
+     * 6. Static files (e.g. /favicon.ico, /sitemap.xml, /robots.txt, etc.)
      */
-    '/((?!api/update_jobs/|_next/|_static|_vercel|[\\w-]+\\.\\w+).*)',
+    '/((?!api/update_jobs/|api/usage-telemetry|_next/|_static|_vercel|[\\w-]+\\.\\w+).*)',
   ],
 };

--- a/apps/dashboard/vercel.json
+++ b/apps/dashboard/vercel.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cleanup/usage-telemetry",
+      "schedule": "0 2 * * *"
+    }
+  ],
   "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" == \"dependabot[bot]\" ]"
 }

--- a/packages/paklo/src/azure/jobs-runner.ts
+++ b/packages/paklo/src/azure/jobs-runner.ts
@@ -9,6 +9,7 @@ import {
   LocalJobsRunner,
   type LocalJobsRunnerOptions,
   mapPackageEcosystemToPackageManager,
+  type RunJobOptions,
   type RunJobsResult,
   runJob,
 } from '@/dependabot';
@@ -208,6 +209,15 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
 
     const results: RunJobsResult = [];
 
+    function makeUsageData(job: DependabotJobConfig): RunJobOptions['usage'] {
+      return {
+        trigger: 'user',
+        provider: job.source.provider,
+        owner: url.url.toString(),
+        'package-manager': job['package-manager'],
+      };
+    }
+
     for (const update of updates) {
       const packageEcosystem = update['package-ecosystem'];
       const packageManager = mapPackageEcosystemToPackageManager(packageEcosystem);
@@ -257,6 +267,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
           credentialsToken,
           updaterImage,
           secretMasker,
+          usage: makeUsageData(job),
         });
 
         const outputs = server.requests(jobId);
@@ -335,6 +346,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
             credentialsToken,
             updaterImage,
             secretMasker,
+            usage: makeUsageData(job),
           });
           const affectedPrs = server.allAffectedPrs(jobId);
           server.clear(jobId);
@@ -369,6 +381,7 @@ export class AzureLocalJobsRunner extends LocalJobsRunner {
               credentialsToken,
               updaterImage,
               secretMasker,
+              usage: makeUsageData(job),
             });
             const affectedPrs = server.allAffectedPrs(jobId);
             server.clear(jobId);

--- a/packages/paklo/src/dependabot/index.ts
+++ b/packages/paklo/src/dependabot/index.ts
@@ -18,3 +18,4 @@ export * from './server';
 export * from './update';
 export * from './updater';
 export * from './updater-builder';
+export * from './usage';

--- a/packages/paklo/src/dependabot/usage.ts
+++ b/packages/paklo/src/dependabot/usage.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod/v4';
+import { DependabotPackageManagerSchema, DependabotSourceProviderSchema } from './job';
+
+/**
+ * @example
+ * ```json
+ * {
+ *   "host": {
+ *     "platform": "darwin",
+ *     "os": "25.0.0",
+ *     "arch": "arm64",
+ *     "machine-hash": "d3bbb66be2ad9dfab10af69b450f7e7e814ef7bbf1277a6d0df9e1db44ba4f5c"
+ *   },
+ *   "trigger": "user",
+ *   "provider": "azure",
+ *   "owner": "https://dev.azure.com/tingle/",
+ *   "package-manager": "terraform",
+ *   "version": "0.9.0",
+ *   "id": 2850677077,
+ *   "started": "2025-10-03T14:44:00.191Z",
+ *   "duration": 31812,
+ *   "success": true
+ * }
+ * ```
+ */
+export const UsageTelemetryRequestDataSchema = z.object({
+  host: z.object({
+    platform: z.string(), // e.g. linux, darwin, win32
+    release: z.string(), // e.g. 26.0.0, 10.0.19043
+    arch: z.string(), // e.g. x64, arm64
+    'machine-hash': z.string(), // e.g. "d3bbb66be2ad9dfab10af69b450f7e7e814ef7bbf1277a6d0df9e1db44ba4f5c" for "Maxwells-MacBook-Pro.local"
+  }),
+  version: z.string(),
+  trigger: z.enum(['user', 'service']),
+  provider: DependabotSourceProviderSchema,
+  owner: z.url(),
+  'package-manager': DependabotPackageManagerSchema,
+  id: z.number(), // job identifier, for correlation
+  started: z.coerce.date(),
+  duration: z.number().min(0), // in milliseconds
+  success: z.boolean(),
+});
+
+/**
+ * @example
+ * ```json
+ * {
+ *   "host": {
+ *     "platform": "darwin",
+ *     "os": "25.0.0",
+ *     "arch": "arm64",
+ *     "machine-hash": "d3bbb66be2ad9dfab10af69b450f7e7e814ef7bbf1277a6d0df9e1db44ba4f5c"
+ *   },
+ *   "trigger": "user",
+ *   "provider": "azure",
+ *   "owner": "https://dev.azure.com/tingle/",
+ *   "package-manager": "terraform",
+ *   "version": "0.9.0",
+ *   "id": 2850677077,
+ *   "started": "2025-10-03T14:44:00.191Z",
+ *   "duration": 31812,
+ *   "success": true
+ * }
+ * ```
+ */
+export type UsageTelemetryRequestData = z.infer<typeof UsageTelemetryRequestDataSchema>;


### PR DESCRIPTION
The information collected is shown in the logs at the end of each job. Nothing sensitive.

This is to help me understand the usage of the tool/extension/cli through a couple of weeks. There is no other source of this information except for when reviews are left but no-one is bothered to leave those or to even want to give feedback via other channels. Do people still use this? Let's find out.

Example payload
```json
{
    "trigger": "user",
    "provider": "azure",
    "owner": "https://dev.azure.com/tingle/",
    "package-manager": "terraform",
    "host": {
        "platform": "darwin",
        "release": "25.0.0",
        "arch": "arm64",
        "machine": "d3bbb66be2ad9dfab10af69b450f7e7e814ef7bbf1277a6d0df9e1db44ba4f5c"
    },
    "version": "0.9.0",
    "id": 4210136136,
    "started": "2025-10-03T14:54:25.565Z",
    "duration": 29307,
    "success": true
}
```